### PR TITLE
remove unnecessary `x` in `line_plot_documentation.py`

### DIFF
--- a/website/more_documentation/line_plot_documentation.py
+++ b/website/more_documentation/line_plot_documentation.py
@@ -10,7 +10,6 @@ def main_demo() -> None:
 
     def update_line_plot() -> None:
         now = datetime.now()
-        x = now.timestamp()
         y1 = math.sin(x)
         y2 = math.cos(x)
         line_plot.push([now], [[y1], [y2]])


### PR DESCRIPTION
`x` is not used on the code in `line_plot_documentation.py`